### PR TITLE
Add dotenv package to project, and load .env file in config.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cookie-parser": "^1.4.6",
+        "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "nconf": "^0.12.0",
         "node-fetch": "^3.3.0"
@@ -214,6 +215,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -1039,6 +1048,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "cookie-parser": "^1.4.6",
+    "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "nconf": "^0.12.0",
     "node-fetch": "^3.3.0"

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,11 @@
 import nconf from 'nconf';
+import * as dotenv from 'dotenv'
+
+/**
+ * Load environment variables from a .env file, if it exists.
+ */
+
+dotenv.config()
 
 /**
  * Parse configuration data from either environment variables, command line


### PR DESCRIPTION
Currently, the guide available on https://discord.com/developers/docs/tutorials/configuring-app-metadata-for-linked-roles guides users to construct a .env file containing their variables; however the project itself does not appear to load environment variables from .env when it is run. This PR looks to add the dotenv module to the project and load the dotenv file when the config file is loaded, such that environment variables are applied to the configuration.