### PR TITLE
fix: metadata key mismatch, missing body parser, null token crash, README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Fetching credentials is covered in detail in the [linked roles tutorial](https:/
 After your credentials are added, you can run your app:
 
 ```
-$ node server.js
+$ node src/server.js
 ```
 
 And, just once, you need to register you connection metadata schema. In a new window, run:

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import * as storage from './storage.js';
 
  const app = express();
  app.use(cookieParser(config.COOKIE_SECRET));
+ app.use(express.json());
 
  /**
   * Just a happy little route to show our server is up.
@@ -103,6 +104,10 @@ app.get('/linked-role', async (req, res) => {
 async function updateMetadata(userId) {
   // Fetch the Discord tokens from storage
   const tokens = await storage.getDiscordTokens(userId);
+
+  if (!tokens) {
+    throw new Error(`No Discord tokens found for user ${userId}`);
+  }
     
   let metadata = {};
   try {
@@ -113,7 +118,7 @@ async function updateMetadata(userId) {
     metadata = {
       cookieseaten: 1483,
       allergictonuts: 0, // 0 for false, 1 for true
-      firstcookiebaked: '2003-12-20',
+      bakingsince: '2003-12-20',
     };
   } catch (e) {
     e.message = `Error fetching external data: ${e.message}`;


### PR DESCRIPTION
## Summary

4 bugs fixed in the sample app that would cause broken functionality for anyone following the tutorial.

## Changes

| File | Bug | Fix |
|------|-----|-----|
| `server.js` | Metadata key `firstcookiebaked` doesn't match registered schema key `bakingsince` in `register.js` | Renamed to `bakingsince` |
| `server.js` | `POST /update-metadata` reads `req.body.userId` but `express.json()` middleware is missing — `userId` is always `undefined` | Added `app.use(express.json())` |
| `server.js` | `updateMetadata()` crashes with `TypeError` if user has no stored tokens (e.g. tokens expired/deleted) | Added null check with descriptive error |
| `README.md` | Getting started says `node server.js` but entry point is at `src/server.js` | Fixed path to `node src/server.js` |

## Impact

- **Key mismatch**: Metadata silently fails to display on linked roles — the registered schema expects `bakingsince` but the app pushes `firstcookiebaked`
- **Missing body parser**: The `/update-metadata` webhook endpoint is completely non-functional
- **Null tokens**: Unhandled crash when tokens are missing from storage